### PR TITLE
Update index.js - `actions: write` in `default_permissions`

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,11 +40,7 @@ const default_permissions = {
   actions_variables: 'write',
   secrets: 'write',
   environments: 'write',
-}
-
-// Required to configure repository oidc customization (e.g. on azure)
-if (process.env.ACTIONS_WRITE === '1') {
-  default_permissions.actions = 'write';
+  actions: 'write',
 }
 
 const webhookUrl = `https://smee.io/${webhookId}`;


### PR DESCRIPTION
Update `index.js` - `actions: write` in `default_permissions`.

In order to:
- Allow triggering GHA from Backstage
- Support the configuration of repo oidc customization for Azure (https://github.com/humanitec-architecture/reference-architecture-azure/issues/23)